### PR TITLE
Fix bug in closing port.

### DIFF
--- a/src/transbank.c
+++ b/src/transbank.c
@@ -199,7 +199,8 @@ int set_normal_mode(){
 }
 
 int close_port(){
-  sp_flush(port, SP_BUF_BOTH);
+  int retval = sp_flush(port, SP_BUF_BOTH);
+  retval += sp_close(port);
   sp_free_port(port);
-  return sp_close(port);
+  return retval;
 }


### PR DESCRIPTION
The structure was being cleaned before the actual port is closed so the pointer was empty when close was called.