### PR TITLE
Add load keys function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,9 @@ Mkfile.old
 dkms.conf
 
 /build/**
+/wrapper/**
 !/build/**/.gitkeep
+!/wrapper/**/.gitkeep
 .DS_Store
 .vscode
 *.code-workspace

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
-build/transbank.o: src/transbank.h src/transbank.c build/TransbankSerialUtils.o
+build/transbank.o: src/transbank.h src/transbank.c
 	cc -c -g src/transbank.c -o build/Transbank.o
 
 build/TransbankSerialUtils.o: src/transbank_serial_utils.h src/transbank_serial_utils.c
 	cc -c -g src/transbank_serial_utils.c -o build/TransbankSerialUtils.o
 
-run: build build/transbank.o build/TransbankSerialUtils.o
+construct: build/transbank.o build/TransbankSerialUtils.o
 	cc -c -g examples/$(example).c -o build/$(example).o -I./src
 	cc -o build/$(example) build/$(example).o build/Transbank.o build/TransbankSerialUtils.o -lserialport
+
+run: build
 	./build/$(example)
 
 debug: build
@@ -26,7 +28,7 @@ windows-wraper:
 
 cmokatest:
 	make
-	cc -o build/test_transbank build/transbank.o build/TransbankSerialUtils.o test/test_transbank.c -lcmocka -lserialport -I./src -Wl,--wrap=write_message,--wrap=read_ack,--wrap=read_bytes,--wrap=sp_input_waiting,--wrap=reply_ack && ./build/test_transbank
+	cc -o build/test_transbank build/transbank.o build/TransbankSerialUtils.o test/test_transbank.c -lcmocka -lserialport -I./src -Wl,--wrap=read_ack,--wrap=write_message && ./build/test_transbank
 
 clean:
 	rm -rf build/*

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,28 @@
-build/main: build/main.o build/transbank.o build/TransbankSerialUtils.o
-	cc -o build/main build/main.o build/Transbank.o build/TransbankSerialUtils.o -lserialport
-
-build/main.o: examples/main.c src/transbank.h src/transbank_serial_utils.h
-	cc -c -g examples/main.c -o build/main.o -I./src
-
 build/transbank.o: src/transbank.h src/transbank.c
 	cc -c -g src/transbank.c -o build/Transbank.o
 
-build/TransbankSerialUtils.o:
+build/TransbankSerialUtils.o: src/transbank_serial_utils.h src/transbank_serial_utils.c
 	cc -c -g src/transbank_serial_utils.c -o build/TransbankSerialUtils.o
 
-run: build/main build/main.o build/Transbank.o build/TransbankSerialUtils.o src/transbank.c src/transbank.h src/transbank_serial_utils.c src/transbank_serial_utils.h
-	./build/main
+construct: build/transbank.o build/TransbankSerialUtils.o
+	cc -c -g examples/$(example).c -o build/$(example).o -I./src
+	cc -o build/$(example) build/$(example).o build/Transbank.o build/TransbankSerialUtils.o -lserialport
 
-debug: examples/main.c src/transbank.h src/transbank.c src/transbank_serial_utils.c src/transbank_serial_utils.h
-	export LIBSERIALPORT_DEBUG=1 && ./build/main && unset LIBSERIALPORT_DEBUG
+run: build
+	./build/$(example)
+
+debug: build
+	export LIBSERIALPORT_DEBUG=1 && ./build/$(example) && unset LIBSERIALPORT_DEBUG
 
 wraper:
-	swig -csharp -o build/transbank_wrap.c -namespace Transbank.POS.Utils src/transbank.i
-	cd build && cc -fpic -c ../src/transbank.c transbank_wrap.c ../src/transbank_serial_utils.c -I../src
+	swig -csharp -o wrapper/transbank_wrap.c -namespace Transbank.POS.Utils src/transbank.i
+	cd build && cc -fpic -c ../src/transbank.c ../wrapper/transbank_wrap.c ../src/transbank_serial_utils.c -I../src
 	cc -dynamiclib build/transbank.o build/transbank_wrap.o build/transbank_serial_utils.o -o build/TransbankWrap.dylib -lserialport
 	sudo cp build/TransbankWrap.dylib /usr/local/lib
 
 windows-wraper:
-	swig -csharp -o build/transbank_wrap.c -namespace Transbank.POS.Utils src/transbank.i
-	cd build && cc -fpic -c ../src/transbank.c transbank_wrap.c ../src/transbank_serial_utils.c -I../src
+	swig -csharp -o wrapper/transbank_wrap.c -namespace Transbank.POS.Utils src/transbank.i
+	cd build && cc -fpic -c ../src/transbank.c ../wrapper/transbank_wrap.c ../src/transbank_serial_utils.c -I../src
 	cc -shared build/transbank.o build/transbank_wrap.o build/transbank_serial_utils.o -o build/TransbankWrap.dll -lserialport
 	cp build/TransbankWrap.dll /c/msys64/mingw64/bin
 
@@ -34,3 +32,4 @@ cmokatest:
 
 clean:
 	rm -rf build/*
+	rm -rf wrapper/*

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,12 @@
-build/transbank.o: src/transbank.h src/transbank.c
+build/transbank.o: src/transbank.h src/transbank.c build/TransbankSerialUtils.o
 	cc -c -g src/transbank.c -o build/Transbank.o
 
 build/TransbankSerialUtils.o: src/transbank_serial_utils.h src/transbank_serial_utils.c
 	cc -c -g src/transbank_serial_utils.c -o build/TransbankSerialUtils.o
 
-construct: build/transbank.o build/TransbankSerialUtils.o
+run: build build/transbank.o build/TransbankSerialUtils.o
 	cc -c -g examples/$(example).c -o build/$(example).o -I./src
 	cc -o build/$(example) build/$(example).o build/Transbank.o build/TransbankSerialUtils.o -lserialport
-
-run: build
 	./build/$(example)
 
 debug: build
@@ -28,7 +26,7 @@ windows-wraper:
 
 cmokatest:
 	make
-	cc -o build/test_transbank build/transbank.o build/TransbankSerialUtils.o test/test_transbank.c -lcmocka -lserialport -I./src -Wl,--wrap=read_ack,--wrap=write_message && ./build/test_transbank
+	cc -o build/test_transbank build/transbank.o build/TransbankSerialUtils.o test/test_transbank.c -lcmocka -lserialport -I./src -Wl,--wrap=write_message,--wrap=read_ack,--wrap=read_bytes,--wrap=sp_input_waiting,--wrap=reply_ack && ./build/test_transbank
 
 clean:
 	rm -rf build/*

--- a/README.md
+++ b/README.md
@@ -39,16 +39,24 @@ This instructiosn asume you have [homebrew](https://brew.sh/) installed.
 - cmoka
 
 
-### Build
+### Examples
+
+#### Build
 
 ```bash
-cc src/hello.c -o build/hello -lserialport
+make construct example=main
 ```
 
-### RUN
+#### RUN
 
 ```bash
-./build/hello
+make run example=main
+```
+
+#### Debug
+
+```bash
+make debug example=main
 ```
 
 ### Install

--- a/examples/load_keys.c
+++ b/examples/load_keys.c
@@ -1,0 +1,28 @@
+#include "transbank.h"
+#include "transbank_serial_utils.h"
+
+int main() {
+
+  char* portName = "COM4";
+  int retval = open_port(portName, 115200);
+  if ( retval == TBK_OK ){
+    puts("Serial port successfully opened.\n");
+
+    LoadKeyCloseResponse rsp = load_keys();
+    printf("MAIN:\n");
+    printf("Function: %i\n", rsp.function);
+    printf("Response Code: %i\n", rsp.responseCode);
+    printf("Commerce Code: %llu\n", rsp.commerceCode);
+    printf("Terminal ID: %lu\n", rsp.terminalId);
+    puts("Keys loaded sucsesfully\n");
+  }
+  //Close Port
+  retval = close_port();
+  if(retval == SP_OK){
+    puts("Serial port closed.\n");
+  } else{
+    puts("Unable to close serial port.\n");
+  }
+
+  return 0;
+}

--- a/examples/load_keys.c
+++ b/examples/load_keys.c
@@ -8,10 +8,8 @@ int main() {
   if ( retval == TBK_OK ){
     puts("Serial port successfully opened.\n");
 
-    LoadKeyCloseResponse rsp;
-    int reval = load_keys(&rsp);
-    printf("MAIN: %p\n", &rsp);
-    printf("Retval: %i\n", retval);
+    LoadKeyCloseResponse rsp = load_keys();
+    printf("MAIN:\n");
     printf("Function: %i\n", rsp.function);
     printf("Response Code: %i\n", rsp.responseCode);
     printf("Commerce Code: %llu\n", rsp.commerceCode);

--- a/examples/load_keys.c
+++ b/examples/load_keys.c
@@ -9,7 +9,7 @@ int main() {
     puts("Serial port successfully opened.\n");
 
     LoadKeyCloseResponse rsp = load_keys();
-    printf("MAIN:\n");
+
     printf("Function: %i\n", rsp.function);
     printf("Response Code: %i\n", rsp.responseCode);
     printf("Commerce Code: %llu\n", rsp.commerceCode);

--- a/examples/load_keys.c
+++ b/examples/load_keys.c
@@ -8,8 +8,10 @@ int main() {
   if ( retval == TBK_OK ){
     puts("Serial port successfully opened.\n");
 
-    LoadKeyCloseResponse rsp = load_keys();
-    printf("MAIN:\n");
+    LoadKeyCloseResponse rsp;
+    int reval = load_keys(&rsp);
+    printf("MAIN: %p\n", &rsp);
+    printf("Retval: %i\n", retval);
     printf("Function: %i\n", rsp.function);
     printf("Response Code: %i\n", rsp.responseCode);
     printf("Commerce Code: %llu\n", rsp.commerceCode);

--- a/src/message.h
+++ b/src/message.h
@@ -1,8 +1,11 @@
-typedef struct message_t Message;
+#ifndef MESSAGEHEADER_FILE
+#define MESSAGEHEADER_FILE
 
-struct message_t {
+typedef struct {
   int payloadSize;
   int responseSize;
   int retries;
   char* payload;
-};
+} Message;
+
+#endif

--- a/src/responses.h
+++ b/src/responses.h
@@ -1,0 +1,17 @@
+#ifndef RESPONSESHEADER_FILE
+#define RESPONSESHEADER_FILE
+
+typedef struct{
+  int index;
+  int length;
+} ParamInfo;
+
+
+typedef struct{
+  int function;
+  int responseCode;
+  long long commerceCode;
+  long terminalId;
+} LoadKeyCloseResponse;
+
+#endif

--- a/src/responses.h
+++ b/src/responses.h
@@ -12,6 +12,7 @@ typedef struct{
   int responseCode;
   long long commerceCode;
   long terminalId;
+  int initilized;
 } LoadKeyCloseResponse;
 
 #endif

--- a/src/transbank.c
+++ b/src/transbank.c
@@ -71,7 +71,10 @@ char* substring(char* string, ParamInfo info){
   memset(ret, '\0', sizeof(ret));
   char cToStr[2];
   cToStr[1] = '\0';
-  for (int i = info.index; i < (info.index + info.length); i++){
+
+  int limit = info.index + info.length;
+
+  for (int i = info.index; i < limit; i++){
     cToStr[0] = string[i];
     strcat(ret, cToStr);
   }

--- a/src/transbank.c
+++ b/src/transbank.c
@@ -66,6 +66,20 @@ int open_port(char* portName, int baudrate){
   return retval;
 }
 
+enum TbkReturn load_keys(){
+  int tries = 0;
+  do{
+    int retval = write_message(port, LOAD_KEYS);
+    if (retval == TBK_OK){
+      if (read_ack(port) == TBK_OK){
+        char* buf;
+        retval = read_bytes(port, buf, LOAD_KEYS);
+      }
+    }
+  } while (tries < LOAD_KEYS.retries);
+  return TBK_NOK;
+}
+
 enum TbkReturn polling(){
   int tries = 0;
   do{
@@ -80,14 +94,12 @@ enum TbkReturn polling(){
   return TBK_NOK;
 }
 
-int set_normal_mode(){
+enum TbkReturn set_normal_mode(){
   int tries = 0;
   do{
     int retval = write_message(port, CHANGE_TO_NORMAL);
     if (retval == TBK_OK){
-      char* returnBuf;
-      retval = read_bytes(port, returnBuf, CHANGE_TO_NORMAL);
-      if (retval == TBK_OK && returnBuf[0] == ACK){
+      if (read_ack(port) == TBK_OK){
         return TBK_OK;
       }
     }

--- a/src/transbank.c
+++ b/src/transbank.c
@@ -108,9 +108,12 @@ enum TbkReturn set_normal_mode(){
   return TBK_NOK;
 }
 
-int close_port(){
+enum TbkReturn close_port(){
   int retval = sp_flush(port, SP_BUF_BOTH);
   retval += sp_close(port);
   sp_free_port(port);
+  if (retval == TBK_OK){
+    return TBK_OK;
+  }
   return retval;
 }

--- a/src/transbank.c
+++ b/src/transbank.c
@@ -91,6 +91,7 @@ LoadKeyCloseResponse* parse_load_keys_response(char* buf){
   response -> responseCode = strtol(substring(buf, responseCode_info), NULL, 10);
   response -> commerceCode = strtoll(substring(buf, commerceCode_info), NULL, 10);
   response -> terminalId = strtol(substring(buf, terminalId_info), NULL, 10);
+  response -> initilized = TBK_OK;
 
   return response;
 }

--- a/src/transbank.h
+++ b/src/transbank.h
@@ -15,7 +15,7 @@ enum TbkReturn{
 };
 
 extern enum TbkReturn open_port(char* portName, int baudrate);
-extern LoadKeyCloseResponse load_keys();
+extern enum TbkReturn load_keys(LoadKeyCloseResponse* rsp);
 extern enum TbkReturn polling();
 extern enum TbkReturn set_normal_mode();
 extern enum TbkReturn close_port();

--- a/src/transbank.h
+++ b/src/transbank.h
@@ -15,7 +15,7 @@ enum TbkReturn{
 };
 
 extern enum TbkReturn open_port(char* portName, int baudrate);
-extern enum TbkReturn load_keys(LoadKeyCloseResponse* rsp);
+extern LoadKeyCloseResponse load_keys();
 extern enum TbkReturn polling();
 extern enum TbkReturn set_normal_mode();
 extern enum TbkReturn close_port();

--- a/src/transbank.h
+++ b/src/transbank.h
@@ -15,7 +15,7 @@ enum TbkReturn{
 
 extern enum TbkReturn open_port(char* portName, int baudrate);
 extern enum TbkReturn polling();
-extern int set_normal_mode();
-extern int close_port();
+extern enum TbkReturn set_normal_mode();
+extern enum TbkReturn close_port();
 
 #endif

--- a/src/transbank.h
+++ b/src/transbank.h
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <libserialport.h>
 #include "message.h"
+#include "responses.h"
 
 enum TbkReturn{
     TBK_OK = 0,
@@ -14,6 +15,7 @@ enum TbkReturn{
 };
 
 extern enum TbkReturn open_port(char* portName, int baudrate);
+extern LoadKeyCloseResponse load_keys();
 extern enum TbkReturn polling();
 extern enum TbkReturn set_normal_mode();
 extern enum TbkReturn close_port();

--- a/src/transbank.i
+++ b/src/transbank.i
@@ -1,7 +1,10 @@
 %module TransbankWrap
 %{
-#include "transbank.h"
+#include "responses.h"
 #include "transbank_serial_utils.h"
+#include "transbank.h"
+
 %}
-%include "transbank.h"
+%include "responses.h"
 %include "transbank_serial_utils.h"
+%include "transbank.h"

--- a/src/transbank_serial_utils.h
+++ b/src/transbank_serial_utils.h
@@ -7,7 +7,7 @@ extern char* list_ports();
 extern char* get_port_name(struct sp_port *port);
 extern int read_bytes(struct sp_port *port, char* buf, Message message);
 extern int read_ack(struct sp_port *port);
-extern int reply_ack(struct sp_port *port);
+extern int reply_ack(struct sp_port *port, char* message, int length);
 extern int write_message(struct sp_port *port, Message message);
 
 #endif

--- a/test/test_transbank.c
+++ b/test/test_transbank.c
@@ -51,7 +51,7 @@ void test_pooling_ack_nok(void **state){
     assert_int_equal((int)TBK_NOK, polling());
 }
 
-void test_ok_on_second_try(void **state){
+void test_pooling_ok_on_second_try(void **state){
     (void) state; /* unused */
     will_return(__wrap_write_message, TBK_NOK);
     will_return(__wrap_write_message, TBK_OK);
@@ -60,7 +60,7 @@ void test_ok_on_second_try(void **state){
     assert_int_equal((int)TBK_OK, polling());
 }
 
-void test_ok_on_third_try(void **state){
+void  test_pooling_ok_on_third_try(void **state){
     (void) state; /* unused */
     will_return_count(__wrap_write_message, TBK_NOK,2);
     will_return(__wrap_write_message, TBK_OK);

--- a/test/test_transbank.c
+++ b/test/test_transbank.c
@@ -12,24 +12,6 @@ int __wrap_read_ack(struct sp_port *port){
     return mock();
 }
 
-int __wrap_read_bytes(struct sp_port *port, char* buf, Message message){
-    char response[] = { 0x02,
-                        0x30, 0x38, 0x31, 0x30, 0x07,
-                        0x30, 0x30, 0x07,
-                        0x35, 0x39, 0x37, 0x30, 0x32, 0x39, 0x34, 0x31, 0x34, 0x33, 0x30, 0x30, 0x07,
-                        0x37, 0x35, 0x30, 0x30, 0x31, 0x30, 0x38, 0x37, 0x03, 0x30, '\0'};
-    strcpy(buf, response);
-    return mock();
-}
-
-int __wrap_sp_input_waiting(struct sp_port *port){
-    return mock();
-}
-
-int __wrap_reply_ack(struct sp_port *port){
-    return mock();
-}
-
 void test_pooling_ok(void **state){
     (void) state; /* unused */
     will_return(__wrap_write_message, TBK_OK);
@@ -50,7 +32,7 @@ void test_pooling_ack_nok(void **state){
     assert_int_equal((int)TBK_NOK, polling());
 }
 
-void test_pooling_ok_on_second_try(void **state){
+void test_ok_on_second_try(void **state){
     (void) state; /* unused */
     will_return(__wrap_write_message, TBK_NOK);
     will_return(__wrap_write_message, TBK_OK);
@@ -59,101 +41,21 @@ void test_pooling_ok_on_second_try(void **state){
     assert_int_equal((int)TBK_OK, polling());
 }
 
-void test_pooling_ok_on_third_try(void **state){
+void test_ok_on_third_try(void **state){
     (void) state; /* unused */
     will_return_count(__wrap_write_message, TBK_NOK,2);
     will_return(__wrap_write_message, TBK_OK);
     will_return_count(__wrap_read_ack, TBK_OK, 1);
 
     assert_int_equal((int)TBK_OK, polling());
-}
-
-void test_set_normal_mode_ok(void **state){
-    (void) state; /* unused */
-    will_return(__wrap_write_message, TBK_OK);
-    will_return(__wrap_read_ack, TBK_OK);
-    assert_int_equal((int)TBK_OK, set_normal_mode());
-}
-
-void test_set_normal_mode_write_nok(void **state){
-    (void) state; /* unused */
-    will_return_count(__wrap_write_message, TBK_NOK, 3);
-    assert_int_equal((int)TBK_NOK, set_normal_mode());
-}
-
-void test_set_normal_mode_ack_nok(void **state){
-    (void) state; /* unused */
-    will_return_count(__wrap_write_message, TBK_OK, 3);
-    will_return_count(__wrap_read_ack, TBK_NOK, 3);
-    assert_int_equal((int)TBK_NOK, set_normal_mode());
-}
-
-void test_set_normal_mode_ok_on_second_try(void **state){
-    (void) state; /* unused */
-    will_return(__wrap_write_message, TBK_NOK);
-    will_return(__wrap_write_message, TBK_OK);
-    will_return_count(__wrap_read_ack, TBK_OK, 1);
-
-    assert_int_equal((int)TBK_OK, set_normal_mode());
-}
-
-void test_set_normal_mode_ok_on_third_try(void **state){
-    (void) state; /* unused */
-    will_return_count(__wrap_write_message, TBK_NOK,2);
-    will_return(__wrap_write_message, TBK_OK);
-    will_return_count(__wrap_read_ack, TBK_OK, 1);
-
-    assert_int_equal((int)TBK_OK, set_normal_mode());
-}
-
-void test_load_keys_ok(void **state){
-    (void) state;
-    will_return(__wrap_write_message, TBK_OK);
-    will_return(__wrap_read_ack, TBK_OK);
-    will_return(__wrap_read_bytes, TBK_OK);
-    will_return(__wrap_reply_ack, TBK_OK);
-    will_return(__wrap_sp_input_waiting, 32);
-
-    LoadKeyCloseResponse rsp;
-    int retval = load_keys(&rsp);
-
-    assert_int_equal(TBK_OK, retval);
-
-    printf("Function: %i\n", rsp.function);
-    assert_int_equal(810, rsp.function);
-
-    printf("responseCode: %i\n", rsp.responseCode);
-    assert_int_equal(0, rsp.responseCode);
-
-    printf("commerceCode: %i\n", rsp.commerceCode);
-    assert_int_equal(597029414300,rsp.commerceCode);
-
-    printf("terminalId: %i\n", rsp.terminalId);
-    assert_int_equal(75001087, rsp.terminalId);
-}
-
-void test_load_keys_nok(void **state){
-    (void) state;
-    will_return_count(__wrap_write_message, TBK_NOK, 3);
-
-    LoadKeyCloseResponse rsp;
-    int retval = load_keys(&rsp);
-    assert_int_equal(TBK_NOK, retval);
 }
 
 const struct CMUnitTest transbank_tests[] = {
     cmocka_unit_test(test_pooling_ok),
     cmocka_unit_test(test_pooling_write_nok),
     cmocka_unit_test(test_pooling_ack_nok),
-    cmocka_unit_test(test_pooling_ok_on_second_try),
-    cmocka_unit_test(test_pooling_ok_on_third_try),
-    cmocka_unit_test(test_set_normal_mode_ok),
-    cmocka_unit_test(test_set_normal_mode_write_nok),
-    cmocka_unit_test(test_set_normal_mode_ack_nok),
-    cmocka_unit_test(test_set_normal_mode_ok_on_second_try),
-    cmocka_unit_test(test_set_normal_mode_ok_on_third_try),
-    cmocka_unit_test(test_load_keys_ok),
-    cmocka_unit_test(test_load_keys_nok)
+    cmocka_unit_test(test_ok_on_second_try),
+    cmocka_unit_test(test_ok_on_third_try)
 };
 
 int main(void)

--- a/test/test_transbank.c
+++ b/test/test_transbank.c
@@ -69,12 +69,117 @@ void  test_pooling_ok_on_third_try(void **state){
     assert_int_equal((int)TBK_OK, polling());
 }
 
+void test_set_normal_mode_ok(void **state){
+    (void) state; /* unused */
+    will_return(__wrap_write_message, TBK_OK);
+    will_return(__wrap_read_ack, TBK_OK);
+    assert_int_equal((int)TBK_OK, set_normal_mode());
+}
+
+void test_set_normal_mode_write_nok(void **state){
+    (void) state; /* unused */
+    will_return_count(__wrap_write_message, TBK_NOK, 3);
+    assert_int_equal((int)TBK_NOK, set_normal_mode());
+}
+
+void test_set_normal_mode_ack_nok(void **state){
+    (void) state; /* unused */
+    will_return_count(__wrap_write_message, TBK_OK, 3);
+    will_return_count(__wrap_read_ack, TBK_NOK, 3);
+    assert_int_equal((int)TBK_NOK, set_normal_mode());
+}
+
+void test_set_normal_mode_ok_on_second_try(void **state){
+    (void) state; /* unused */
+    will_return(__wrap_write_message, TBK_NOK);
+    will_return(__wrap_write_message, TBK_OK);
+    will_return_count(__wrap_read_ack, TBK_OK, 1);
+
+    assert_int_equal((int)TBK_OK, set_normal_mode());
+}
+
+void test_set_normal_mode_ok_on_third_try(void **state){
+    (void) state; /* unused */
+    will_return_count(__wrap_write_message, TBK_NOK,2);
+    will_return(__wrap_write_message, TBK_OK);
+    will_return_count(__wrap_read_ack, TBK_OK, 1);
+
+    assert_int_equal((int)TBK_OK, set_normal_mode());
+}
+
+void test_load_keys_ok(void **state){
+    (void) state;
+    will_return(__wrap_write_message, TBK_OK);
+    will_return(__wrap_read_ack, TBK_OK);
+    will_return(__wrap_read_bytes, TBK_OK);
+    will_return(__wrap_reply_ack, TBK_OK);
+    will_return(__wrap_sp_input_waiting, 32);
+
+    LoadKeyCloseResponse response = load_keys();
+
+    assert_int_equal(810, response.function);
+    assert_int_equal(0, response.responseCode);
+    assert_int_equal(597029414300,response.commerceCode);
+    assert_int_equal(75001087, response.terminalId);
+    assert_int_equal(TBK_OK, response.initilized);
+}
+
+void test_load_keys_nok(void **state){
+    (void) state;
+    will_return_count(__wrap_write_message, TBK_NOK, 3);
+
+    LoadKeyCloseResponse response = load_keys();
+    assert_int_equal(NULL, response.initilized);
+}
+
+void test_load_keys_ack_nok(void **state){
+    (void) state;
+    will_return_count(__wrap_write_message, TBK_OK, 3);
+    will_return_count(__wrap_read_ack, TBK_NOK,3);
+
+    LoadKeyCloseResponse response = load_keys();
+    assert_int_equal(NULL, response.initilized);
+}
+
+void test_load_keys_read_bytes_nok(void **state){
+    (void) state;
+    will_return(__wrap_write_message, TBK_OK);
+    will_return(__wrap_read_ack, TBK_OK);
+    will_return_count(__wrap_read_bytes, TBK_NOK, 3);
+    will_return_count(__wrap_sp_input_waiting, 32, 4);
+
+    LoadKeyCloseResponse response = load_keys();
+    assert_int_equal(NULL, response.initilized);
+}
+
+void test_load_keys_reply_ack_nok(void **state){
+    (void) state;
+    will_return(__wrap_write_message, TBK_OK);
+    will_return(__wrap_read_ack, TBK_OK);
+    will_return_count(__wrap_read_bytes, TBK_OK, 3);
+    will_return_count(__wrap_sp_input_waiting, 32, 4);
+    will_return_count(__wrap_reply_ack, TBK_NOK, 3);
+
+    LoadKeyCloseResponse response = load_keys();
+    assert_int_equal(NULL, response.initilized);
+}
+
 const struct CMUnitTest transbank_tests[] = {
     cmocka_unit_test(test_pooling_ok),
     cmocka_unit_test(test_pooling_write_nok),
     cmocka_unit_test(test_pooling_ack_nok),
-    cmocka_unit_test(test_ok_on_second_try),
-    cmocka_unit_test(test_ok_on_third_try)
+    cmocka_unit_test(test_pooling_ok_on_second_try),
+    cmocka_unit_test( test_pooling_ok_on_third_try),
+    cmocka_unit_test(test_set_normal_mode_ok),
+    cmocka_unit_test(test_set_normal_mode_write_nok),
+    cmocka_unit_test(test_set_normal_mode_ack_nok),
+    cmocka_unit_test(test_set_normal_mode_ok_on_second_try),
+    cmocka_unit_test(test_set_normal_mode_ok_on_third_try),
+    cmocka_unit_test(test_load_keys_ok),
+    cmocka_unit_test(test_load_keys_nok),
+    cmocka_unit_test(test_load_keys_ack_nok),
+    cmocka_unit_test(test_load_keys_read_bytes_nok),
+    cmocka_unit_test(test_load_keys_reply_ack_nok)
 };
 
 int main(void)

--- a/test/test_transbank.c
+++ b/test/test_transbank.c
@@ -12,6 +12,25 @@ int __wrap_read_ack(struct sp_port *port){
     return mock();
 }
 
+int __wrap_read_bytes(struct sp_port *port, char* buf, Message message){
+    char response[] = { 0x02,
+                        0x30, 0x38, 0x31, 0x30, 0x07,
+                        0x30, 0x30, 0x07,
+                        0x35, 0x39, 0x37, 0x30, 0x32, 0x39, 0x34, 0x31, 0x34, 0x33, 0x30, 0x30, 0x07,
+                        0x37, 0x35, 0x30, 0x30, 0x31, 0x30, 0x38, 0x37, 0x03, 0x30, '\0'};
+    strcpy(buf, response);
+    return mock();
+}
+
+int __wrap_sp_input_waiting(struct sp_port *port){
+    return mock();
+}
+
+int __wrap_reply_ack(struct sp_port *port, char* message, int length){
+    return mock();
+}
+
+
 void test_pooling_ok(void **state){
     (void) state; /* unused */
     will_return(__wrap_write_message, TBK_OK);

--- a/test/test_transbank.c
+++ b/test/test_transbank.c
@@ -12,6 +12,24 @@ int __wrap_read_ack(struct sp_port *port){
     return mock();
 }
 
+int __wrap_read_bytes(struct sp_port *port, char* buf, Message message){
+    char response[] = { 0x02,
+                        0x30, 0x38, 0x31, 0x30, 0x07,
+                        0x30, 0x30, 0x07,
+                        0x35, 0x39, 0x37, 0x30, 0x32, 0x39, 0x34, 0x31, 0x34, 0x33, 0x30, 0x30, 0x07,
+                        0x37, 0x35, 0x30, 0x30, 0x31, 0x30, 0x38, 0x37, 0x03, 0x30, '\0'};
+    strcpy(buf, response);
+    return mock();
+}
+
+int __wrap_sp_input_waiting(struct sp_port *port){
+    return mock();
+}
+
+int __wrap_reply_ack(struct sp_port *port){
+    return mock();
+}
+
 void test_pooling_ok(void **state){
     (void) state; /* unused */
     will_return(__wrap_write_message, TBK_OK);
@@ -32,7 +50,7 @@ void test_pooling_ack_nok(void **state){
     assert_int_equal((int)TBK_NOK, polling());
 }
 
-void test_ok_on_second_try(void **state){
+void test_pooling_ok_on_second_try(void **state){
     (void) state; /* unused */
     will_return(__wrap_write_message, TBK_NOK);
     will_return(__wrap_write_message, TBK_OK);
@@ -41,7 +59,7 @@ void test_ok_on_second_try(void **state){
     assert_int_equal((int)TBK_OK, polling());
 }
 
-void test_ok_on_third_try(void **state){
+void test_pooling_ok_on_third_try(void **state){
     (void) state; /* unused */
     will_return_count(__wrap_write_message, TBK_NOK,2);
     will_return(__wrap_write_message, TBK_OK);
@@ -50,12 +68,92 @@ void test_ok_on_third_try(void **state){
     assert_int_equal((int)TBK_OK, polling());
 }
 
+void test_set_normal_mode_ok(void **state){
+    (void) state; /* unused */
+    will_return(__wrap_write_message, TBK_OK);
+    will_return(__wrap_read_ack, TBK_OK);
+    assert_int_equal((int)TBK_OK, set_normal_mode());
+}
+
+void test_set_normal_mode_write_nok(void **state){
+    (void) state; /* unused */
+    will_return_count(__wrap_write_message, TBK_NOK, 3);
+    assert_int_equal((int)TBK_NOK, set_normal_mode());
+}
+
+void test_set_normal_mode_ack_nok(void **state){
+    (void) state; /* unused */
+    will_return_count(__wrap_write_message, TBK_OK, 3);
+    will_return_count(__wrap_read_ack, TBK_NOK, 3);
+    assert_int_equal((int)TBK_NOK, set_normal_mode());
+}
+
+void test_set_normal_mode_ok_on_second_try(void **state){
+    (void) state; /* unused */
+    will_return(__wrap_write_message, TBK_NOK);
+    will_return(__wrap_write_message, TBK_OK);
+    will_return_count(__wrap_read_ack, TBK_OK, 1);
+
+    assert_int_equal((int)TBK_OK, set_normal_mode());
+}
+
+void test_set_normal_mode_ok_on_third_try(void **state){
+    (void) state; /* unused */
+    will_return_count(__wrap_write_message, TBK_NOK,2);
+    will_return(__wrap_write_message, TBK_OK);
+    will_return_count(__wrap_read_ack, TBK_OK, 1);
+
+    assert_int_equal((int)TBK_OK, set_normal_mode());
+}
+
+void test_load_keys_ok(void **state){
+    (void) state;
+    will_return(__wrap_write_message, TBK_OK);
+    will_return(__wrap_read_ack, TBK_OK);
+    will_return(__wrap_read_bytes, TBK_OK);
+    will_return(__wrap_reply_ack, TBK_OK);
+    will_return(__wrap_sp_input_waiting, 32);
+
+    LoadKeyCloseResponse rsp;
+    int retval = load_keys(&rsp);
+
+    assert_int_equal(TBK_OK, retval);
+
+    printf("Function: %i\n", rsp.function);
+    assert_int_equal(810, rsp.function);
+
+    printf("responseCode: %i\n", rsp.responseCode);
+    assert_int_equal(0, rsp.responseCode);
+
+    printf("commerceCode: %i\n", rsp.commerceCode);
+    assert_int_equal(597029414300,rsp.commerceCode);
+
+    printf("terminalId: %i\n", rsp.terminalId);
+    assert_int_equal(75001087, rsp.terminalId);
+}
+
+void test_load_keys_nok(void **state){
+    (void) state;
+    will_return_count(__wrap_write_message, TBK_NOK, 3);
+
+    LoadKeyCloseResponse rsp;
+    int retval = load_keys(&rsp);
+    assert_int_equal(TBK_NOK, retval);
+}
+
 const struct CMUnitTest transbank_tests[] = {
     cmocka_unit_test(test_pooling_ok),
     cmocka_unit_test(test_pooling_write_nok),
     cmocka_unit_test(test_pooling_ack_nok),
-    cmocka_unit_test(test_ok_on_second_try),
-    cmocka_unit_test(test_ok_on_third_try)
+    cmocka_unit_test(test_pooling_ok_on_second_try),
+    cmocka_unit_test(test_pooling_ok_on_third_try),
+    cmocka_unit_test(test_set_normal_mode_ok),
+    cmocka_unit_test(test_set_normal_mode_write_nok),
+    cmocka_unit_test(test_set_normal_mode_ack_nok),
+    cmocka_unit_test(test_set_normal_mode_ok_on_second_try),
+    cmocka_unit_test(test_set_normal_mode_ok_on_third_try),
+    cmocka_unit_test(test_load_keys_ok),
+    cmocka_unit_test(test_load_keys_nok)
 };
 
 int main(void)


### PR DESCRIPTION

- Adds `LoadKey` method.
- Adds `Response.h` and a struct for `LoadKeys` and `Close` responses.
- Adds `LoadKeys.c` example.
- Allows to run different examples passing `example=foo` in the `make run` command.
- Move the generated Swig files to the `Wrapper` folder.
- Update read_bytes to check the length of the response.
