### PR TITLE
Rename LoadKeyCloseResponse to Base Response

### DIFF
--- a/examples/close_register.c
+++ b/examples/close_register.c
@@ -7,7 +7,7 @@ int main() {
   int retval = open_port(portName, 115200);
   if ( retval == TBK_OK ){
     puts("Serial port successfully opened.\n");
-    LoadKeyCloseResponse response = register_close();
+    BaseResponse response = register_close();
 
     if (response.initilized ){
       printf("Function: %i\n", response.function);

--- a/examples/load_keys.c
+++ b/examples/load_keys.c
@@ -8,7 +8,7 @@ int main() {
   if ( retval == TBK_OK ){
     puts("Serial port successfully opened.\n");
 
-    LoadKeyCloseResponse rsp = load_keys();
+    BaseResponse rsp = load_keys();
 
     printf("Function: %i\n", rsp.function);
     printf("Response Code: %i\n", rsp.responseCode);

--- a/examples/register_close.c
+++ b/examples/register_close.c
@@ -8,7 +8,7 @@ int main() {
   if ( retval == TBK_OK ){
     puts("Serial port successfully opened.\n");
 
-    LoadKeyCloseResponse rsp = register_close();
+    BaseResponse rsp = register_close();
 
     printf("Function: %i\n", rsp.function);
     printf("Response Code: %i\n", rsp.responseCode);

--- a/src/responses.h
+++ b/src/responses.h
@@ -13,6 +13,6 @@ typedef struct{
   long long commerceCode;
   int terminalId;
   int initilized;
-} LoadKeyCloseResponse;
+} BaseResponse;
 
 #endif

--- a/src/transbank.c
+++ b/src/transbank.c
@@ -89,13 +89,13 @@ char* substring(char* string, ParamInfo info){
   return ret;
 }
 
-LoadKeyCloseResponse* parse_load_keys_close_response(char* buf){
+BaseResponse* parse_load_keys_close_response(char* buf){
   ParamInfo function_info = {1,4};
   ParamInfo responseCode_info = {6,2};
   ParamInfo commerceCode_info= {9, 12};
   ParamInfo terminalId_info={22,8};
 
-  LoadKeyCloseResponse* response = malloc(sizeof(LoadKeyCloseResponse));
+  BaseResponse* response = malloc(sizeof(BaseResponse));
 
   response -> function = strtol(substring(buf,function_info), NULL, 10);
   response -> responseCode = strtol(substring(buf, responseCode_info), NULL, 10);
@@ -196,10 +196,10 @@ char* sale(int amount, int ticket, bool send_messages){
   }
 }
 
-LoadKeyCloseResponse register_close(){
+BaseResponse register_close(){
   int tries = 0;
   int retval, write_ok = TBK_NOK;
-  LoadKeyCloseResponse *rsp;
+  BaseResponse *rsp;
 
   do{
     int retval = write_message(port, REGISTER_CLOSE);
@@ -239,10 +239,10 @@ LoadKeyCloseResponse register_close(){
   return *rsp;
 }
 
-LoadKeyCloseResponse load_keys(){
+BaseResponse load_keys(){
   int tries = 0;
   int retval, write_ok = TBK_NOK;
-  LoadKeyCloseResponse *rsp;
+  BaseResponse *rsp;
 
   do{
     int retval = write_message(port, LOAD_KEYS);

--- a/src/transbank.h
+++ b/src/transbank.h
@@ -17,8 +17,8 @@ enum TbkReturn{
 
 extern enum TbkReturn open_port(char* portName, int baudrate);
 extern char* sale(int amount, int ticket, bool send_messages);
-extern LoadKeyCloseResponse register_close();
-extern LoadKeyCloseResponse load_keys();
+extern BaseResponse register_close();
+extern BaseResponse load_keys();
 extern enum TbkReturn polling();
 extern enum TbkReturn set_normal_mode();
 extern enum TbkReturn close_port();

--- a/test/test_transbank.c
+++ b/test/test_transbank.c
@@ -115,7 +115,7 @@ void test_load_keys_ok(void **state){
     will_return(__wrap_reply_ack, 0);
     will_return(__wrap_sp_input_waiting, 32);
 
-    LoadKeyCloseResponse response = load_keys();
+    BaseResponse response = load_keys();
 
     assert_int_equal(810, response.function);
     assert_int_equal(0, response.responseCode);
@@ -128,7 +128,7 @@ void test_load_keys_nok(void **state){
     (void) state;
     will_return_count(__wrap_write_message, TBK_NOK, 3);
 
-    LoadKeyCloseResponse response = load_keys();
+    BaseResponse response = load_keys();
     assert_int_equal(NULL, response.initilized);
 }
 
@@ -137,7 +137,7 @@ void test_load_keys_ack_nok(void **state){
     will_return_count(__wrap_write_message, TBK_OK, 3);
     will_return_count(__wrap_read_ack, TBK_NOK,3);
 
-    LoadKeyCloseResponse response = load_keys();
+    BaseResponse response = load_keys();
     assert_int_equal(NULL, response.initilized);
 }
 
@@ -148,7 +148,7 @@ void test_load_keys_read_bytes_nok(void **state){
     will_return_count(__wrap_read_bytes, -1, 3);
     will_return_count(__wrap_sp_input_waiting, 32, 4);
 
-    LoadKeyCloseResponse response = load_keys();
+    BaseResponse response = load_keys();
     assert_int_equal(NULL, response.initilized);
 }
 
@@ -160,7 +160,7 @@ void test_load_keys_reply_ack_nok(void **state){
     will_return_count(__wrap_sp_input_waiting, 32, 4);
     will_return_count(__wrap_reply_ack, -1, 3);
 
-    LoadKeyCloseResponse response = load_keys();
+    BaseResponse response = load_keys();
     assert_int_equal(NULL, response.initilized);
 }
 


### PR DESCRIPTION
This is done because, this is the minimum set of parameters you can get
from the POS, and they are always present int any complex response
(Those with more than one ASCII char in it)