### PR TITLE
Rename NACK to NAK

### DIFF
--- a/src/hex_codes.h
+++ b/src/hex_codes.h
@@ -1,6 +1,6 @@
 enum HexCodes{
   ACK = 0x06,
-  NACK = 0x15,
+  NAK = 0x15,
   STX = 0x02,
   ETX = 0x03,
   PIPE = 0x7C

--- a/src/transbank_serial_utils.c
+++ b/src/transbank_serial_utils.c
@@ -75,7 +75,7 @@ unsigned char calculate_lrc(char* message, int length){
 }
 
 int reply_ack(struct sp_port *port, char* message, int length){
-  char buf[] = {NACK};
+  char buf[] = {NAK};
   int retval = TBK_NOK;
 
   sp_flush(port, SP_BUF_BOTH);


### PR DESCRIPTION
The ASCII name of a negative aknowledge is NAK not NACK