### PR TITLE
Rename Refund and Totals Responses

### DIFF
--- a/examples/refund.c
+++ b/examples/refund.c
@@ -13,7 +13,7 @@ int main()
     int op;
     scanf("%i", &op);
 
-    RefundResponse response = refund(op); // refund(transactionID)
+    RefundCResponse response = refund(op); // refund(transactionID)
     if (response.initilized == TBK_OK)
     {
       printf("REFUND RESPONSE\n=============\n");

--- a/examples/totals.c
+++ b/examples/totals.c
@@ -12,7 +12,7 @@ int main()
 
     printf("Getting Totals from POS...\n");
 
-    TotalsResponse response = get_totals();
+    TotalsCResponse response = get_totals();
     if (response.initilized == TBK_OK)
     {
       printf("POS CONNECTED\n=============\n");

--- a/src/responses.h
+++ b/src/responses.h
@@ -23,7 +23,7 @@ typedef struct
   int txCount;
   int txTotal;
   int initilized;
-} TotalsResponse;
+} TotalsCResponse;
 
 typedef struct
 {
@@ -34,6 +34,6 @@ typedef struct
   char authorizationCode[7];
   int operationID;
   int initilized;
-} RefundResponse;
+} RefundCResponse;
 
 #endif

--- a/src/transbank.c
+++ b/src/transbank.c
@@ -155,9 +155,9 @@ BaseResponse *parse_load_keys_close_response(char *buf)
   return response;
 }
 
-TotalsResponse *parse_get_totals_response(char *buf)
+TotalsCResponse *parse_get_totals_response(char *buf)
 {
-  TotalsResponse *response = malloc(sizeof(TotalsResponse));
+  TotalsCResponse *response = malloc(sizeof(TotalsCResponse));
 
   char *word;
   int init_pos = 1, length = 0, found = 0;
@@ -538,12 +538,12 @@ enum TbkReturn close_port()
   return retval;
 }
 
-TotalsResponse get_totals()
+TotalsCResponse get_totals()
 {
   int tries = 0;
   int retval, write_ok = TBK_NOK;
 
-  TotalsResponse *rsp = malloc(sizeof(TotalsResponse));
+  TotalsCResponse *rsp = malloc(sizeof(TotalsCResponse));
   rsp->initilized = TBK_NOK;
 
   do
@@ -633,9 +633,9 @@ Message prepare_refund_message(int transactionID)
   return message;
 }
 
-RefundResponse *parse_refund_response(char *buf)
+RefundCResponse *parse_refund_response(char *buf)
 {
-  RefundResponse *response = malloc(sizeof(RefundResponse));
+  RefundCResponse *response = malloc(sizeof(RefundCResponse));
   response->initilized = TBK_NOK;
 
   char *word;
@@ -693,12 +693,12 @@ RefundResponse *parse_refund_response(char *buf)
   return response;
 }
 
-RefundResponse refund(int transactionID)
+RefundCResponse refund(int transactionID)
 {
   int tries = 0;
   int retval, write_ok = TBK_NOK;
 
-  RefundResponse *rsp = malloc(sizeof(RefundResponse));
+  RefundCResponse *rsp = malloc(sizeof(RefundCResponse));
   rsp->initilized = TBK_NOK;
 
   Message refund_message = prepare_refund_message(transactionID);

--- a/src/transbank.h
+++ b/src/transbank.h
@@ -22,11 +22,11 @@ extern char *sale(int amount, int ticket, bool send_messages);
 extern char *last_sale();
 extern BaseResponse close();
 extern BaseResponse load_keys();
-extern TotalsResponse get_totals();
+extern TotalsCResponse get_totals();
 extern enum TbkReturn poll();
 extern enum TbkReturn set_normal_mode();
 extern enum TbkReturn close_port();
-extern RefundResponse refund(int transactionID);
+extern RefundCResponse refund(int transactionID);
 extern char *sales_detail(bool print_on_pos);
 
 #endif

--- a/test/test_transbank.c
+++ b/test/test_transbank.c
@@ -468,7 +468,7 @@ void test_get_totals_ok(void **state)
   will_return(__wrap_read_bytes, 19);
   will_return(__wrap_reply_ack, 0);
 
-  TotalsResponse response = get_totals();
+  TotalsCResponse response = get_totals();
 
   assert_int_equal(710, response.function);
   assert_int_equal(0, response.responseCode);
@@ -481,7 +481,7 @@ void test_get_totals_nok(void **state)
   (void)state;
   will_return_count(__wrap_write_message, TBK_NOK, 3);
 
-  TotalsResponse response = get_totals();
+  TotalsCResponse response = get_totals();
   assert_int_equal(TBK_NOK, response.initilized);
 }
 
@@ -493,7 +493,7 @@ void test_get_totals_read_bytes_nok(void **state)
   will_return_count(__wrap_read_bytes, -1, 3);
   will_return_count(__wrap_sp_input_waiting, 32, 4);
 
-  TotalsResponse response = get_totals();
+  TotalsCResponse response = get_totals();
   assert_int_equal(TBK_NOK, response.initilized);
 }
 
@@ -506,7 +506,7 @@ void test_get_totals_reply_ack_nok(void **state)
   will_return_count(__wrap_sp_input_waiting, 32, 4);
   will_return_count(__wrap_reply_ack, -1, 3);
 
-  TotalsResponse response = get_totals();
+  TotalsCResponse response = get_totals();
   assert_int_equal(TBK_NOK, response.initilized);
 }
 
@@ -520,7 +520,7 @@ void test_refund_ok(void **state)
   will_return(__wrap_read_bytes, 34);
   will_return(__wrap_reply_ack, 0);
 
-  RefundResponse response = refund(10);
+  RefundCResponse response = refund(10);
 
   assert_int_equal(1210, response.function);
   assert_int_equal(0, response.responseCode);
@@ -532,7 +532,7 @@ void test_refund_nok(void **state)
   (void)state;
   will_return_count(__wrap_write_message, TBK_NOK, 3);
 
-  RefundResponse response = refund(9);
+  RefundCResponse response = refund(9);
   assert_int_equal(TBK_NOK, response.initilized);
 }
 
@@ -544,7 +544,7 @@ void test_refund_read_bytes_nok(void **state)
   will_return_count(__wrap_read_bytes, -1, 3);
   will_return_count(__wrap_sp_input_waiting, 34, 4);
 
-  RefundResponse response = refund(9);
+  RefundCResponse response = refund(9);
   assert_int_equal(TBK_NOK, response.initilized);
 }
 
@@ -557,7 +557,7 @@ void test_refund_reply_ack_nok(void **state)
   will_return_count(__wrap_sp_input_waiting, 34, 4);
   will_return_count(__wrap_reply_ack, -1, 3);
 
-  RefundResponse response = refund(9);
+  RefundCResponse response = refund(9);
   assert_int_equal(TBK_NOK, response.initilized);
 }
 


### PR DESCRIPTION
Had to rename to Cresponse in order to follow the naming convention in the C# SDK