### PR TITLE
Bug when no option is selected on sale

### DIFF
--- a/src/transbank.c
+++ b/src/transbank.c
@@ -281,7 +281,7 @@ char *sale(int amount, char* ticket, bool send_messages)
     int wait = sp_input_waiting(port);
     do
     {
-      if (wait > 65)
+      if (wait > 64)
       {
         int readedbytes = read_bytes(port, buf, sale_message);
         if (readedbytes > 0)


### PR DESCRIPTION
Error message when no option is selected is 64 char length